### PR TITLE
change flow definition to Nat

### DIFF
--- a/FlowEquivalentForest/Matrix.lean
+++ b/FlowEquivalentForest/Matrix.lean
@@ -81,7 +81,7 @@ def mkFlowEquivalentForest
       have : v ≠ v := edges_ne h
       contradiction
     simp only [*, ne_eq, dite_false]
-  have symm : ∀ {u v}, cap u v = cap v u := by
+  have symm : ∀ u v, cap u v = cap v u := by
     intro u v
     if huv : (u, v) ∈ edges g then
       have huv_ne := edges_ne huv

--- a/FlowEquivalentForest/Network.lean
+++ b/FlowEquivalentForest/Network.lean
@@ -13,7 +13,7 @@ structure Network where
   loopless: ∀ v, cap v v = 0
 
 structure UndirectedNetwork extends Network V where
-  symm: ∀ {u v}, cap u v = cap v u
+  symm: ∀ u v, cap u v = cap v u
 
 end
 


### PR DESCRIPTION
Flows on edges are now natural numbers with the constraint that the flow in one direction has to equal zero. This pr fixes all previously working proofs and it seems to be way easier. Just look at how much the diff deleted.